### PR TITLE
Fix Location serialization name (`Uri` -> `uri`).

### DIFF
--- a/LanguageServer/Parameters/Location.cs
+++ b/LanguageServer/Parameters/Location.cs
@@ -6,7 +6,7 @@ namespace LanguageServer.Parameters
 {
     public class Location
     {
-        public Uri Uri { get; set; }
+        public Uri uri { get; set; }
         public Range range { get; set; }
     }
 }


### PR DESCRIPTION
It blocked textDocument/definition etc. as LSP clients (vscode etc.) did
not recognize `Uri` property.